### PR TITLE
specify encoding explicitly in case it isn't utf-8 (e.g. on windows)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,7 @@ class GeocodeData:
         """Load a map of country code to name
         """
         self.__countries = {}
-        with open(country_filename, 'r') as handler:
+        with open(country_filename, 'r', encoding='utf-8') as handler:
             for code, name in csv.reader(handler):
                 self.__countries[code] = name
 
@@ -72,7 +72,7 @@ class GeocodeData:
         """
         if os.path.exists(local_filename):
             # open compact CSV
-            rows = csv.reader(open(local_filename, 'r'))
+            rows = csv.reader(open(local_filename, 'r', encoding='utf-8'))
         else:
             if not os.path.exists(GEOCODE_FILENAME):
                 # remove GEOCODE_FILENAME to get updated data
@@ -83,9 +83,9 @@ class GeocodeData:
                 z.close()
 
             # extract coordinates into more compact CSV for faster loading
-            writer = csv.writer(open(local_filename, 'w'))
+            writer = csv.writer(open(local_filename, 'w', encoding='utf-8'))
             rows = []
-            for row in csv.reader(open(GEOCODE_FILENAME, 'r'), delimiter='\t'):
+            for row in csv.reader(open(GEOCODE_FILENAME, 'r', encoding='utf-8'), delimiter='\t'):
                 latitude, longitude = row[4:6]
                 country_code = row[8]
                 if latitude and longitude and country_code:


### PR DESCRIPTION
on windows this currently fails with a trace like:
```
  File "c:\utils\Python\Python37\lib\site-packages\reverse_geocode\__init__.py", line 121, in search
    gd = GeocodeData()
  File "c:\utils\Python\Python37\lib\site-packages\reverse_geocode\__init__.py", line 25, in getinstance
    instances[cls] = cls()
  File "c:\utils\Python\Python37\lib\site-packages\reverse_geocode\__init__.py", line 34, in __init__
    coordinates, self.locations = self.extract(rel_path(geocode_filename))
  File "c:\utils\Python\Python37\lib\site-packages\reverse_geocode\__init__.py", line 100, in extract
    for latitude, longitude, country_code, city in rows:
  File "c:\utils\Python\Python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 464: character maps to <undefined>
```
because the file system encoding defaults to cp1252 rather than utf-8, and geocode.csv is in utf-8. Specifying the encoding works around this (and obscure cases on linux where somebody has set LC_TYPE to something other than utf-8).